### PR TITLE
feat: implement stock risk dashboard with log returns and volatility

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -1,1 +1,183 @@
-# stock-risk-dashboard
+# Stock Risk Dashboard - Architecture
+
+## Overview
+
+A real-time stock analysis dashboard that fetches historical price data from Yahoo Finance and calculates key risk metrics: **log returns**, **annualized volatility**, and **analysis period**.
+
+---
+
+## System Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                        USER BROWSER                          │
+│                                                             │
+│  ┌─────────────────────────────────────────────────────┐   │
+│  │         Angular 18 Frontend (localhost:4200)         │   │
+│  │                                                      │   │
+│  │  ┌──────────────┐    ┌──────────────────────────┐   │   │
+│  │  │ AppComponent │───▶│   DashboardComponent     │   │   │
+│  │  └──────────────┘    │  - Stock symbol search   │   │   │
+│  │                      │  - Metrics display       │   │   │
+│  │                      │  - Price sparkline       │   │   │
+│  │                      │  - Log returns table     │   │   │
+│  │                      └──────────┬───────────────┘   │   │
+│  │                                 │                    │   │
+│  │                      ┌──────────▼───────────────┐   │   │
+│  │                      │      StockService         │   │   │
+│  │                      │  HTTP GET /api/stock/     │   │   │
+│  │                      │  {symbol}/metrics        │   │   │
+│  │                      └──────────────────────────┘   │   │
+│  └─────────────────────────────────────────────────────┘   │
+└──────────────────────────┬──────────────────────────────────┘
+                           │ HTTP REST (localhost:8080)
+                           │
+┌──────────────────────────▼──────────────────────────────────┐
+│              Spring Boot Backend (Java 21, port 8080)        │
+│                                                             │
+│  ┌──────────────────────────────────────────────────────┐   │
+│  │                   StockController                    │   │
+│  │  GET /api/stock/{symbol}/metrics                     │   │
+│  │  GET /api/stock/health                               │   │
+│  └────────────────────────┬─────────────────────────────┘   │
+│                           │                                 │
+│  ┌────────────────────────▼─────────────────────────────┐   │
+│  │                   StockService                       │   │
+│  │                                                      │   │
+│  │  1. fetchFromYahooFinance(symbol)                    │   │
+│  │  2. parseAndCalculate(symbol, response)              │   │
+│  │  3. calculateLogReturns(prices)                      │   │
+│  │  4. calculateAnnualizedVolatility(logReturns)        │   │
+│  └────────────────────────┬─────────────────────────────┘   │
+│                           │                                 │
+│  ┌────────────────────────▼─────────────────────────────┐   │
+│  │               StockMetrics (Response DTO)            │   │
+│  │  - symbol, companyName, currentPrice                 │   │
+│  │  - volatility (annualized %)                         │   │
+│  │  - averageLogReturn                                  │   │
+│  │  - period (trading days)                             │   │
+│  │  - logReturns[], dates[], closePrices[]              │   │
+│  └──────────────────────────────────────────────────────┘   │
+└──────────────────────────┬──────────────────────────────────┘
+                           │ HTTPS (Yahoo Finance v8 API)
+                           │
+┌──────────────────────────▼──────────────────────────────────┐
+│              Yahoo Finance API (External)                    │
+│  query1.finance.yahoo.com/v8/finance/chart/{symbol}         │
+│  Parameters: range=1y, interval=1d                          │
+│  Returns: timestamps, OHLCV data (~252 trading days)        │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Component Details
+
+### Backend (`/backend`)
+
+| Component | Class | Responsibility |
+|-----------|-------|---------------|
+| Controller | `StockController` | REST API entry point, request validation, error mapping |
+| Service | `StockService` | Yahoo Finance fetch, log return & volatility calculation |
+| Model | `StockMetrics` | Response DTO with all calculated metrics |
+| Exception | `StockDataException` | Domain-specific error for bad symbol or API failure |
+
+**Key Calculations:**
+- **Log Return**: `ln(P_t / P_{t-1})` for each consecutive trading day
+- **Annualized Volatility**: `std_dev(logReturns) × √252` expressed as a percentage
+- **Period**: count of log return data points (typically ~251 for 1-year range)
+
+### Frontend (`/frontend`)
+
+| Component | File | Responsibility |
+|-----------|------|---------------|
+| App | `app.component.ts` | Root component with navbar |
+| Dashboard | `dashboard/dashboard.component.ts` | Stock search, metrics display, chart |
+| Service | `services/stock.service.ts` | HTTP calls to backend REST API |
+| Model | `models/stock-metrics.model.ts` | TypeScript interface for API response |
+
+---
+
+## API Reference
+
+### `GET /api/stock/{symbol}/metrics`
+
+Returns calculated risk metrics for the given stock symbol.
+
+**Response (200 OK):**
+```json
+{
+  "symbol": "AAPL",
+  "companyName": "Apple Inc.",
+  "currentPrice": 172.45,
+  "volatility": 24.87,
+  "averageLogReturn": 0.0009,
+  "period": 251,
+  "logReturns": [0.0123, -0.0045, ...],
+  "dates": ["2024-03-28", ...],
+  "closePrices": [172.45, 169.12, ...]
+}
+```
+
+**Error Response (400 Bad Request):**
+```json
+{
+  "error": "No data found for symbol: INVALID"
+}
+```
+
+### `GET /api/stock/health`
+
+Health check endpoint. Returns `200 OK` with plain text message.
+
+---
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Backend Runtime | Java 21 |
+| Backend Framework | Spring Boot 3.3.0 |
+| Build Tool | Maven |
+| JSON Parsing | Gson 2.10.1 |
+| Frontend Framework | Angular 18 |
+| Frontend Language | TypeScript 5.4 |
+| UI Library | Bootstrap 5.3 |
+| External Data | Yahoo Finance v8 API |
+| Containerization | Docker (eclipse-temurin:21-jdk-jammy) |
+| CI/CD | GitHub Actions |
+
+---
+
+## Data Flow
+
+```
+User types "AAPL"
+    │
+    ▼
+DashboardComponent.search()
+    │
+    ▼
+StockService.getStockMetrics("AAPL")
+    │  HTTP GET localhost:8080/api/stock/AAPL/metrics
+    ▼
+StockController.getStockMetrics("AAPL")
+    │
+    ▼
+StockService.fetchFromYahooFinance("AAPL")
+    │  HTTP GET query1.finance.yahoo.com/v8/finance/chart/AAPL?range=1y&interval=1d
+    ▼
+Yahoo Finance API returns ~252 daily OHLCV records
+    │
+    ▼
+StockService.parseAndCalculate()
+    ├── Extract close prices and timestamps
+    ├── calculateLogReturns() → ln(P_t/P_{t-1}) for each day
+    └── calculateAnnualizedVolatility() → std_dev × √252
+    │
+    ▼
+StockMetrics DTO serialized as JSON
+    │
+    ▼
+Angular renders metrics cards, price sparkline, returns table
+```

--- a/backend/src/main/java/com/stockrisk/controller/StockController.java
+++ b/backend/src/main/java/com/stockrisk/controller/StockController.java
@@ -1,0 +1,38 @@
+package com.stockrisk.controller;
+
+import com.stockrisk.exception.StockDataException;
+import com.stockrisk.model.StockMetrics;
+import com.stockrisk.service.StockService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/stock")
+public class StockController {
+
+    private final StockService stockService;
+
+    public StockController(StockService stockService) {
+        this.stockService = stockService;
+    }
+
+    @GetMapping("/{symbol}/metrics")
+    public ResponseEntity<StockMetrics> getStockMetrics(
+            @PathVariable String symbol) {
+        try {
+            StockMetrics metrics = stockService.getStockMetrics(symbol);
+            return ResponseEntity.ok(metrics);
+        } catch (StockDataException e) {
+            StockMetrics error = new StockMetrics(e.getMessage());
+            return ResponseEntity.badRequest().body(error);
+        } catch (Exception e) {
+            StockMetrics error = new StockMetrics("Internal server error: " + e.getMessage());
+            return ResponseEntity.internalServerError().body(error);
+        }
+    }
+
+    @GetMapping("/health")
+    public ResponseEntity<String> health() {
+        return ResponseEntity.ok("Stock Risk Dashboard API is running");
+    }
+}

--- a/backend/src/main/java/com/stockrisk/exception/StockDataException.java
+++ b/backend/src/main/java/com/stockrisk/exception/StockDataException.java
@@ -1,0 +1,12 @@
+package com.stockrisk.exception;
+
+public class StockDataException extends RuntimeException {
+
+    public StockDataException(String message) {
+        super(message);
+    }
+
+    public StockDataException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/backend/src/main/java/com/stockrisk/model/StockMetrics.java
+++ b/backend/src/main/java/com/stockrisk/model/StockMetrics.java
@@ -1,0 +1,53 @@
+package com.stockrisk.model;
+
+import java.util.List;
+
+public class StockMetrics {
+
+    private String symbol;
+    private String companyName;
+    private double currentPrice;
+    private double volatility;          // annualized volatility (%)
+    private double averageLogReturn;    // average daily log return
+    private int period;                 // number of trading days analyzed
+    private List<Double> logReturns;
+    private List<String> dates;
+    private List<Double> closePrices;
+    private String error;
+
+    public StockMetrics() {}
+
+    public StockMetrics(String error) {
+        this.error = error;
+    }
+
+    public String getSymbol() { return symbol; }
+    public void setSymbol(String symbol) { this.symbol = symbol; }
+
+    public String getCompanyName() { return companyName; }
+    public void setCompanyName(String companyName) { this.companyName = companyName; }
+
+    public double getCurrentPrice() { return currentPrice; }
+    public void setCurrentPrice(double currentPrice) { this.currentPrice = currentPrice; }
+
+    public double getVolatility() { return volatility; }
+    public void setVolatility(double volatility) { this.volatility = volatility; }
+
+    public double getAverageLogReturn() { return averageLogReturn; }
+    public void setAverageLogReturn(double averageLogReturn) { this.averageLogReturn = averageLogReturn; }
+
+    public int getPeriod() { return period; }
+    public void setPeriod(int period) { this.period = period; }
+
+    public List<Double> getLogReturns() { return logReturns; }
+    public void setLogReturns(List<Double> logReturns) { this.logReturns = logReturns; }
+
+    public List<String> getDates() { return dates; }
+    public void setDates(List<String> dates) { this.dates = dates; }
+
+    public List<Double> getClosePrices() { return closePrices; }
+    public void setClosePrices(List<Double> closePrices) { this.closePrices = closePrices; }
+
+    public String getError() { return error; }
+    public void setError(String error) { this.error = error; }
+}

--- a/backend/src/main/java/com/stockrisk/service/StockService.java
+++ b/backend/src/main/java/com/stockrisk/service/StockService.java
@@ -1,0 +1,146 @@
+package com.stockrisk.service;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.stockrisk.exception.StockDataException;
+import com.stockrisk.model.StockMetrics;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class StockService {
+
+    private static final String YAHOO_FINANCE_URL =
+            "https://query1.finance.yahoo.com/v8/finance/chart/{symbol}?range=1y&interval=1d";
+
+    private static final int TRADING_DAYS_PER_YEAR = 252;
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+    private final RestClient restClient;
+
+    public StockService() {
+        this.restClient = RestClient.builder()
+                .defaultHeader("User-Agent",
+                        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36")
+                .defaultHeader("Accept", "application/json")
+                .build();
+    }
+
+    public StockMetrics getStockMetrics(String symbol) {
+        String upperSymbol = symbol.toUpperCase().trim();
+        String responseBody = fetchFromYahooFinance(upperSymbol);
+        return parseAndCalculate(upperSymbol, responseBody);
+    }
+
+    private String fetchFromYahooFinance(String symbol) {
+        try {
+            return restClient.get()
+                    .uri(YAHOO_FINANCE_URL, symbol)
+                    .retrieve()
+                    .body(String.class);
+        } catch (Exception e) {
+            throw new StockDataException("Failed to fetch data for symbol: " + symbol, e);
+        }
+    }
+
+    private StockMetrics parseAndCalculate(String symbol, String responseBody) {
+        JsonObject root = JsonParser.parseString(responseBody).getAsJsonObject();
+        JsonObject chart = root.getAsJsonObject("chart");
+
+        JsonElement errorElement = chart.get("error");
+        if (errorElement != null && !errorElement.isJsonNull()) {
+            throw new StockDataException("Yahoo Finance error for symbol: " + symbol);
+        }
+
+        JsonArray results = chart.getAsJsonArray("result");
+        if (results == null || results.isEmpty()) {
+            throw new StockDataException("No data found for symbol: " + symbol);
+        }
+
+        JsonObject result = results.get(0).getAsJsonObject();
+        JsonObject meta = result.getAsJsonObject("meta");
+        JsonArray timestamps = result.getAsJsonArray("timestamp");
+
+        JsonObject indicators = result.getAsJsonObject("indicators");
+        JsonArray quoteArray = indicators.getAsJsonArray("quote");
+        JsonObject quote = quoteArray.get(0).getAsJsonObject();
+        JsonArray closeArray = quote.getAsJsonArray("close");
+
+        // Extract close prices and dates, filtering out nulls
+        List<Double> closePrices = new ArrayList<>();
+        List<String> dates = new ArrayList<>();
+
+        for (int i = 0; i < closeArray.size(); i++) {
+            JsonElement closeEl = closeArray.get(i);
+            if (!closeEl.isJsonNull()) {
+                closePrices.add(closeEl.getAsDouble());
+                long epochSeconds = timestamps.get(i).getAsLong();
+                LocalDate date = Instant.ofEpochSecond(epochSeconds)
+                        .atZone(ZoneOffset.UTC).toLocalDate();
+                dates.add(date.format(DATE_FORMATTER));
+            }
+        }
+
+        if (closePrices.size() < 2) {
+            throw new StockDataException("Insufficient price data for symbol: " + symbol);
+        }
+
+        // Calculate log returns: ln(P_t / P_{t-1})
+        List<Double> logReturns = calculateLogReturns(closePrices);
+
+        // Calculate annualized volatility: std_dev(logReturns) * sqrt(252)
+        double volatility = calculateAnnualizedVolatility(logReturns);
+
+        // Average daily log return
+        double avgLogReturn = logReturns.stream()
+                .mapToDouble(Double::doubleValue)
+                .average()
+                .orElse(0.0);
+
+        StockMetrics metrics = new StockMetrics();
+        metrics.setSymbol(symbol);
+        metrics.setCompanyName(meta.has("longName") && !meta.get("longName").isJsonNull()
+                ? meta.get("longName").getAsString()
+                : meta.has("shortName") && !meta.get("shortName").isJsonNull()
+                        ? meta.get("shortName").getAsString() : symbol);
+        metrics.setCurrentPrice(closePrices.get(closePrices.size() - 1));
+        metrics.setVolatility(round4(volatility * 100)); // as percentage
+        metrics.setAverageLogReturn(round4(avgLogReturn));
+        metrics.setPeriod(logReturns.size());
+        metrics.setLogReturns(logReturns.stream().map(this::round4).toList());
+        metrics.setDates(dates.subList(1, dates.size())); // align with logReturns (skip first)
+        metrics.setClosePrices(closePrices);
+
+        return metrics;
+    }
+
+    List<Double> calculateLogReturns(List<Double> prices) {
+        List<Double> logReturns = new ArrayList<>(prices.size() - 1);
+        for (int i = 1; i < prices.size(); i++) {
+            double logReturn = Math.log(prices.get(i) / prices.get(i - 1));
+            logReturns.add(logReturn);
+        }
+        return logReturns;
+    }
+
+    double calculateAnnualizedVolatility(List<Double> logReturns) {
+        double mean = logReturns.stream().mapToDouble(Double::doubleValue).average().orElse(0.0);
+        double variance = logReturns.stream()
+                .mapToDouble(r -> Math.pow(r - mean, 2))
+                .sum() / (logReturns.size() - 1);
+        return Math.sqrt(variance) * Math.sqrt(TRADING_DAYS_PER_YEAR);
+    }
+
+    private double round4(double value) {
+        return Math.round(value * 10000.0) / 10000.0;
+    }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,0 +1,9 @@
+spring.application.name=stock-risk-dashboard
+server.port=8080
+
+# Logging
+logging.level.com.stockrisk=INFO
+logging.level.org.springframework.web.client=WARN
+
+# Jackson
+spring.jackson.serialization.write-dates-as-timestamps=false

--- a/backend/src/test/java/com/stockrisk/service/StockServiceTest.java
+++ b/backend/src/test/java/com/stockrisk/service/StockServiceTest.java
@@ -1,0 +1,71 @@
+package com.stockrisk.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class StockServiceTest {
+
+    private StockService stockService;
+
+    @BeforeEach
+    void setUp() {
+        stockService = new StockService();
+    }
+
+    @Test
+    void calculateLogReturns_returnsCorrectValues() {
+        List<Double> prices = Arrays.asList(100.0, 110.0, 105.0, 115.0);
+        List<Double> logReturns = stockService.calculateLogReturns(prices);
+
+        assertEquals(3, logReturns.size());
+        assertEquals(Math.log(110.0 / 100.0), logReturns.get(0), 1e-9);
+        assertEquals(Math.log(105.0 / 110.0), logReturns.get(1), 1e-9);
+        assertEquals(Math.log(115.0 / 105.0), logReturns.get(2), 1e-9);
+    }
+
+    @Test
+    void calculateLogReturns_singlePairReturnsOneValue() {
+        List<Double> prices = Arrays.asList(50.0, 55.0);
+        List<Double> logReturns = stockService.calculateLogReturns(prices);
+
+        assertEquals(1, logReturns.size());
+        assertEquals(Math.log(55.0 / 50.0), logReturns.get(0), 1e-9);
+    }
+
+    @Test
+    void calculateAnnualizedVolatility_constantReturnsZeroVolatility() {
+        // If all returns are equal, std dev = 0, volatility = 0
+        List<Double> constantReturns = Arrays.asList(0.01, 0.01, 0.01, 0.01, 0.01);
+        double volatility = stockService.calculateAnnualizedVolatility(constantReturns);
+
+        assertEquals(0.0, volatility, 1e-9);
+    }
+
+    @Test
+    void calculateAnnualizedVolatility_knownValues() {
+        // Simple case: two values with known std dev
+        List<Double> returns = Arrays.asList(0.1, -0.1);
+        double volatility = stockService.calculateAnnualizedVolatility(returns);
+
+        // std dev of [0.1, -0.1] = 0.1 * sqrt(2) / sqrt(1) = 0.1414...
+        // annualized = std_dev * sqrt(252)
+        double expectedStdDev = Math.sqrt(Math.pow(0.1 - 0.0, 2) + Math.pow(-0.1 - 0.0, 2));
+        // sample std dev with n-1 denominator
+        double sampleStdDev = Math.sqrt((Math.pow(0.1, 2) + Math.pow(0.1, 2)) / 1.0);
+        double expectedVolatility = sampleStdDev * Math.sqrt(252);
+
+        assertEquals(expectedVolatility, volatility, 1e-9);
+    }
+
+    @Test
+    void calculateLogReturns_emptyWhenSinglePrice() {
+        List<Double> prices = Arrays.asList(100.0);
+        List<Double> logReturns = stockService.calculateLogReturns(prices);
+        assertTrue(logReturns.isEmpty());
+    }
+}

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
+  "version": 1,
+  "newProjectRoot": "projects",
+  "projects": {
+    "stock-risk-dashboard": {
+      "projectType": "application",
+      "schematics": {
+        "@schematics/angular:component": {
+          "style": "css"
+        }
+      },
+      "root": "",
+      "sourceRoot": "src",
+      "prefix": "app",
+      "architect": {
+        "build": {
+          "builder": "@angular-devkit/build-angular:application",
+          "options": {
+            "outputPath": "dist/stock-risk-dashboard",
+            "index": "src/index.html",
+            "browser": "src/main.ts",
+            "polyfills": ["zone.js"],
+            "tsConfig": "tsconfig.app.json",
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": [
+              "node_modules/bootstrap/dist/css/bootstrap.min.css",
+              "src/styles.css"
+            ],
+            "scripts": []
+          },
+          "configurations": {
+            "production": {
+              "budgets": [
+                {
+                  "type": "initial",
+                  "maximumWarning": "500kb",
+                  "maximumError": "1mb"
+                }
+              ],
+              "outputHashing": "all"
+            },
+            "development": {
+              "optimization": false,
+              "extractLicenses": false,
+              "sourceMap": true
+            }
+          },
+          "defaultConfiguration": "production"
+        },
+        "serve": {
+          "builder": "@angular-devkit/build-angular:dev-server",
+          "configurations": {
+            "production": {
+              "buildTarget": "stock-risk-dashboard:build:production"
+            },
+            "development": {
+              "buildTarget": "stock-risk-dashboard:build:development"
+            }
+          },
+          "defaultConfiguration": "development"
+        },
+        "test": {
+          "builder": "@angular-devkit/build-angular:karma",
+          "options": {
+            "polyfills": ["zone.js", "zone.js/testing"],
+            "tsConfig": "tsconfig.spec.json",
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": [
+              "node_modules/bootstrap/dist/css/bootstrap.min.css",
+              "src/styles.css"
+            ],
+            "scripts": []
+          }
+        }
+      }
+    }
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "stock-risk-dashboard",
+  "version": "0.0.0",
+  "scripts": {
+    "ng": "ng",
+    "start": "ng serve",
+    "build": "ng build",
+    "watch": "ng build --watch --configuration development",
+    "test": "ng test"
+  },
+  "private": true,
+  "dependencies": {
+    "@angular/animations": "^18.0.0",
+    "@angular/common": "^18.0.0",
+    "@angular/compiler": "^18.0.0",
+    "@angular/core": "^18.0.0",
+    "@angular/forms": "^18.0.0",
+    "@angular/platform-browser": "^18.0.0",
+    "@angular/platform-browser-dynamic": "^18.0.0",
+    "@angular/router": "^18.0.0",
+    "bootstrap": "^5.3.0",
+    "rxjs": "~7.8.0",
+    "tslib": "^2.3.0",
+    "zone.js": "~0.14.3"
+  },
+  "devDependencies": {
+    "@angular-devkit/build-angular": "^18.0.0",
+    "@angular/cli": "^18.0.0",
+    "@angular/compiler-cli": "^18.0.0",
+    "@types/jasmine": "~5.1.0",
+    "jasmine-core": "~5.1.0",
+    "karma": "~6.4.0",
+    "karma-chrome-launcher": "~3.2.0",
+    "karma-coverage": "~2.2.0",
+    "karma-jasmine": "~5.1.0",
+    "karma-jasmine-html-reporter": "~2.1.0",
+    "typescript": "~5.4.0"
+  }
+}

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -1,0 +1,20 @@
+import { Component } from '@angular/core';
+import { DashboardComponent } from './components/dashboard/dashboard.component';
+
+@Component({
+  selector: 'app-root',
+  standalone: true,
+  imports: [DashboardComponent],
+  template: `
+    <nav class="navbar navbar-dark" style="background-color: #161b22; border-bottom: 1px solid #30363d;">
+      <div class="container-fluid px-4">
+        <span class="navbar-brand">
+          📊 Stock Risk Dashboard
+        </span>
+        <span class="text-muted small">Powered by Yahoo Finance</span>
+      </div>
+    </nav>
+    <app-dashboard></app-dashboard>
+  `
+})
+export class AppComponent {}

--- a/frontend/src/app/components/dashboard/dashboard.component.css
+++ b/frontend/src/app/components/dashboard/dashboard.component.css
@@ -1,0 +1,8 @@
+/* Dashboard-specific styles */
+.metric-card {
+  transition: transform 0.2s ease;
+}
+
+.metric-card:hover {
+  transform: translateY(-2px);
+}

--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -1,0 +1,209 @@
+<div class="container-fluid py-4">
+
+  <!-- Search Bar -->
+  <div class="row justify-content-center mb-4">
+    <div class="col-md-6">
+      <div class="input-group">
+        <input
+          type="text"
+          class="form-control search-input"
+          placeholder="Enter stock symbol (e.g. AAPL, TSLA)"
+          [(ngModel)]="symbol"
+          (keyup.enter)="search()"
+          [disabled]="loading"
+        />
+        <button
+          class="btn btn-primary px-4"
+          (click)="search()"
+          [disabled]="loading || !symbol.trim()"
+        >
+          <span *ngIf="loading" class="spinner-border spinner-border-sm me-2"></span>
+          {{ loading ? 'Loading...' : 'Analyze' }}
+        </button>
+      </div>
+      <!-- Quick symbol buttons -->
+      <div class="mt-2">
+        <small class="text-muted me-2">Quick picks:</small>
+        <button
+          *ngFor="let s of recentSymbols; trackBy: trackByIndex"
+          class="btn btn-sm btn-outline-secondary me-1 mb-1"
+          (click)="loadMetrics(s)"
+          [disabled]="loading"
+        >{{ s }}</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Error State -->
+  <div *ngIf="errorMessage" class="row justify-content-center mb-4">
+    <div class="col-md-8">
+      <div class="alert alert-danger" role="alert">
+        <strong>Error:</strong> {{ errorMessage }}
+      </div>
+    </div>
+  </div>
+
+  <!-- Loading State -->
+  <div *ngIf="loading" class="spinner-container">
+    <div class="text-center">
+      <div class="spinner-border text-primary" style="width: 3rem; height: 3rem;"></div>
+      <p class="mt-3 text-muted">Fetching stock data from Yahoo Finance...</p>
+    </div>
+  </div>
+
+  <!-- Results -->
+  <div *ngIf="metrics && !loading">
+
+    <!-- Header -->
+    <div class="row justify-content-center mb-4">
+      <div class="col-md-10">
+        <div class="d-flex align-items-center justify-content-between">
+          <div>
+            <h2 class="mb-0 fw-bold">{{ metrics.symbol }}</h2>
+            <p class="text-muted mb-0">{{ metrics.companyName }}</p>
+          </div>
+          <div class="text-end">
+            <div class="fs-3 fw-bold">${{ metrics.currentPrice | number:'1.2-2' }}</div>
+            <small class="text-muted">Current Price</small>
+          </div>
+        </div>
+        <hr style="border-color: #30363d;">
+      </div>
+    </div>
+
+    <!-- Key Metrics Cards -->
+    <div class="row justify-content-center mb-4">
+      <div class="col-md-10">
+        <div class="row g-3">
+
+          <!-- Volatility -->
+          <div class="col-md-4">
+            <div class="card metric-card h-100">
+              <div class="metric-label mb-2">Annualized Volatility</div>
+              <div class="metric-value" [ngClass]="volatilityClass">
+                {{ metrics.volatility | number:'1.2-2' }}%
+              </div>
+              <div class="mt-2">
+                <span class="badge rounded-pill px-3 py-2"
+                  [ngClass]="{
+                    'bg-danger': metrics.volatility > 40,
+                    'bg-warning text-dark': metrics.volatility > 20 && metrics.volatility <= 40,
+                    'bg-success': metrics.volatility <= 20
+                  }">
+                  {{ volatilityLabel }} RISK
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <!-- Avg Log Return -->
+          <div class="col-md-4">
+            <div class="card metric-card h-100">
+              <div class="metric-label mb-2">Avg Daily Log Return</div>
+              <div class="metric-value"
+                [ngClass]="metrics.averageLogReturn >= 0 ? 'log-return-positive' : 'log-return-negative'">
+                {{ metrics.averageLogReturn >= 0 ? '+' : '' }}{{ metrics.averageLogReturn | number:'1.4-4' }}
+              </div>
+              <div class="mt-2 text-muted small">
+                {{ (metrics.averageLogReturn * 252 * 100) | number:'1.2-2' }}% annualized
+              </div>
+            </div>
+          </div>
+
+          <!-- Period -->
+          <div class="col-md-4">
+            <div class="card metric-card h-100">
+              <div class="metric-label mb-2">Analysis Period</div>
+              <div class="metric-value text-info">
+                {{ metrics.period }}
+              </div>
+              <div class="mt-2 text-muted small">
+                trading days (~{{ (metrics.period / 252) | number:'1.1-1' }} year)
+              </div>
+            </div>
+          </div>
+
+        </div>
+      </div>
+    </div>
+
+    <!-- Price Chart (sparkline-style) -->
+    <div class="row justify-content-center mb-4">
+      <div class="col-md-10">
+        <div class="card">
+          <div class="card-header">
+            <h6 class="mb-0">Price History (1 Year)</h6>
+          </div>
+          <div class="card-body p-3">
+            <div class="d-flex align-items-end gap-0" style="height: 120px; overflow-x: auto;">
+              <div
+                *ngFor="let price of metrics.closePrices; trackBy: trackByIndex"
+                [style.height.%]="priceBarHeight(price)"
+                [style.min-width.px]="3"
+                [style.background-color]="price >= metrics.closePrices[0] ? '#3fb950' : '#f85149'"
+                [title]="'$' + (price | number:'1.2-2')"
+                class="flex-shrink-0"
+                style="margin-right: 1px; border-radius: 1px;"
+              ></div>
+            </div>
+            <div class="d-flex justify-content-between mt-1">
+              <small class="text-muted">{{ metrics.dates[0] }}</small>
+              <small class="text-muted">{{ metrics.dates[metrics.dates.length - 1] }}</small>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Log Returns Table -->
+    <div class="row justify-content-center mb-4">
+      <div class="col-md-10">
+        <div class="card">
+          <div class="card-header d-flex justify-content-between align-items-center">
+            <h6 class="mb-0">Daily Log Returns</h6>
+            <button class="btn btn-sm btn-outline-secondary"
+              (click)="showAllReturns = !showAllReturns">
+              {{ showAllReturns ? 'Show Less' : 'Show All ' + metrics.period }}
+            </button>
+          </div>
+          <div class="card-body p-0" style="max-height: 300px; overflow-y: auto;">
+            <table class="table table-sm returns-table mb-0">
+              <thead style="position: sticky; top: 0; background: #1c2128;">
+                <tr>
+                  <th class="ps-3">Date</th>
+                  <th class="text-end pe-3">Log Return</th>
+                  <th class="text-end pe-3">Direction</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr *ngFor="let row of displayedReturns; trackBy: trackByIndex">
+                  <td class="ps-3">{{ row.date }}</td>
+                  <td class="text-end pe-3"
+                    [ngClass]="row.value >= 0 ? 'log-return-positive' : 'log-return-negative'">
+                    {{ row.value >= 0 ? '+' : '' }}{{ row.value | number:'1.4-4' }}
+                  </td>
+                  <td class="text-end pe-3">
+                    <span [ngClass]="row.value >= 0 ? 'log-return-positive' : 'log-return-negative'">
+                      {{ row.value >= 0 ? '▲' : '▼' }}
+                    </span>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+  <!-- Empty State -->
+  <div *ngIf="!metrics && !loading && !errorMessage" class="row justify-content-center">
+    <div class="col-md-6 text-center py-5">
+      <div class="display-1 mb-3">📈</div>
+      <h4 class="text-muted">Enter a stock symbol to analyze</h4>
+      <p class="text-muted">Get real-time log returns, volatility metrics, and price history powered by Yahoo Finance</p>
+    </div>
+  </div>
+
+</div>

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -1,0 +1,93 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { StockService } from '../../services/stock.service';
+import { StockMetrics } from '../../models/stock-metrics.model';
+
+@Component({
+  selector: 'app-dashboard',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './dashboard.component.html',
+  styleUrls: ['./dashboard.component.css']
+})
+export class DashboardComponent {
+  symbol = '';
+  metrics: StockMetrics | null = null;
+  loading = false;
+  errorMessage = '';
+  recentSymbols: string[] = ['AAPL', 'MSFT', 'GOOGL', 'TSLA', 'AMZN'];
+  showAllReturns = false;
+
+  constructor(private stockService: StockService) {}
+
+  search(): void {
+    const trimmed = this.symbol.trim().toUpperCase();
+    if (!trimmed) return;
+    this.loadMetrics(trimmed);
+  }
+
+  loadMetrics(sym: string): void {
+    this.symbol = sym;
+    this.loading = true;
+    this.errorMessage = '';
+    this.metrics = null;
+    this.showAllReturns = false;
+
+    this.stockService.getStockMetrics(sym).subscribe({
+      next: (data) => {
+        if (data.error) {
+          this.errorMessage = data.error;
+        } else {
+          this.metrics = data;
+        }
+        this.loading = false;
+      },
+      error: (err) => {
+        this.errorMessage = err.message;
+        this.loading = false;
+      }
+    });
+  }
+
+  get volatilityClass(): string {
+    if (!this.metrics) return '';
+    if (this.metrics.volatility > 40) return 'volatility-high';
+    if (this.metrics.volatility > 20) return 'volatility-medium';
+    return 'volatility-low';
+  }
+
+  get volatilityLabel(): string {
+    if (!this.metrics) return '';
+    if (this.metrics.volatility > 40) return 'HIGH';
+    if (this.metrics.volatility > 20) return 'MEDIUM';
+    return 'LOW';
+  }
+
+  get displayedReturns(): { date: string; value: number }[] {
+    if (!this.metrics) return [];
+    const entries = this.metrics.dates.map((d, i) => ({
+      date: d,
+      value: this.metrics!.logReturns[i]
+    }));
+    return this.showAllReturns ? entries : entries.slice(-20);
+  }
+
+  get maxPrice(): number {
+    return this.metrics ? Math.max(...this.metrics.closePrices) : 1;
+  }
+
+  get minPrice(): number {
+    return this.metrics ? Math.min(...this.metrics.closePrices) : 0;
+  }
+
+  priceBarHeight(price: number): number {
+    const range = this.maxPrice - this.minPrice;
+    if (range === 0) return 50;
+    return ((price - this.minPrice) / range) * 100;
+  }
+
+  trackByIndex(index: number): number {
+    return index;
+  }
+}

--- a/frontend/src/app/models/stock-metrics.model.ts
+++ b/frontend/src/app/models/stock-metrics.model.ts
@@ -1,0 +1,12 @@
+export interface StockMetrics {
+  symbol: string;
+  companyName: string;
+  currentPrice: number;
+  volatility: number;          // annualized volatility as percentage
+  averageLogReturn: number;    // average daily log return
+  period: number;              // number of trading days analyzed
+  logReturns: number[];
+  dates: string[];
+  closePrices: number[];
+  error?: string;
+}

--- a/frontend/src/app/services/stock.service.ts
+++ b/frontend/src/app/services/stock.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { Observable, throwError } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+import { StockMetrics } from '../models/stock-metrics.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class StockService {
+  private readonly apiUrl = 'http://localhost:8080/api/stock';
+
+  constructor(private http: HttpClient) {}
+
+  getStockMetrics(symbol: string): Observable<StockMetrics> {
+    return this.http.get<StockMetrics>(`${this.apiUrl}/${symbol}/metrics`).pipe(
+      catchError(this.handleError)
+    );
+  }
+
+  private handleError(error: HttpErrorResponse): Observable<never> {
+    let message = 'An unexpected error occurred';
+    if (error.status === 0) {
+      message = 'Cannot connect to backend. Make sure the server is running on port 8080.';
+    } else if (error.status === 400 && error.error?.error) {
+      message = error.error.error;
+    } else if (error.status === 500) {
+      message = 'Server error. Please try again later.';
+    }
+    return throwError(() => new Error(message));
+  }
+}

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Stock Risk Dashboard</title>
+  <base href="/">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="icon" type="image/x-icon" href="favicon.ico">
+</head>
+<body>
+  <app-root></app-root>
+</body>
+</html>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,0 +1,11 @@
+import { bootstrapApplication } from '@angular/platform-browser';
+import { AppComponent } from './app/app.component';
+import { provideHttpClient } from '@angular/common/http';
+import { provideAnimations } from '@angular/platform-browser/animations';
+
+bootstrapApplication(AppComponent, {
+  providers: [
+    provideHttpClient(),
+    provideAnimations()
+  ]
+}).catch(err => console.error(err));

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,97 @@
+/* Global Styles */
+body {
+  background-color: #0d1117;
+  color: #e6edf3;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+.navbar-brand {
+  font-weight: 700;
+  font-size: 1.4rem;
+}
+
+.card {
+  background-color: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 8px;
+}
+
+.card-header {
+  background-color: #1c2128;
+  border-bottom: 1px solid #30363d;
+}
+
+.metric-card {
+  text-align: center;
+  padding: 1.5rem;
+}
+
+.metric-value {
+  font-size: 2rem;
+  font-weight: 700;
+  color: #58a6ff;
+}
+
+.metric-label {
+  font-size: 0.85rem;
+  color: #8b949e;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.volatility-high { color: #f85149; }
+.volatility-medium { color: #e3b341; }
+.volatility-low { color: #3fb950; }
+
+.log-return-positive { color: #3fb950; }
+.log-return-negative { color: #f85149; }
+
+.price-chart-container {
+  height: 300px;
+  overflow-x: auto;
+}
+
+.search-input {
+  background-color: #0d1117;
+  border: 1px solid #30363d;
+  color: #e6edf3;
+  border-radius: 6px;
+}
+
+.search-input:focus {
+  background-color: #0d1117;
+  border-color: #58a6ff;
+  color: #e6edf3;
+  box-shadow: 0 0 0 0.25rem rgba(88, 166, 255, 0.25);
+}
+
+.btn-primary {
+  background-color: #238636;
+  border-color: #238636;
+}
+
+.btn-primary:hover {
+  background-color: #2ea043;
+  border-color: #2ea043;
+}
+
+.spinner-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 200px;
+}
+
+.returns-table {
+  font-size: 0.875rem;
+}
+
+.returns-table td, .returns-table th {
+  border-color: #30363d;
+  color: #e6edf3;
+  background-color: transparent;
+}
+
+.badge-info {
+  background-color: #1f6feb;
+}

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/app",
+    "types": []
+  },
+  "files": [
+    "src/main.ts"
+  ],
+  "include": [
+    "src/**/*.d.ts"
+  ]
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "outDir": "./dist/out-tsc",
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "sourceMap": true,
+    "declaration": false,
+    "downlevelIteration": true,
+    "experimentalDecorators": true,
+    "moduleResolution": "bundler",
+    "importHelpers": true,
+    "target": "ES2022",
+    "module": "ES2022",
+    "useDefineForClassFields": false,
+    "lib": ["ES2022", "dom"]
+  },
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  }
+}

--- a/frontend/tsconfig.spec.json
+++ b/frontend/tsconfig.spec.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/spec",
+    "types": ["jasmine"]
+  },
+  "include": [
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}


### PR DESCRIPTION
## Summary

Implements the full Stock Risk Dashboard as described in issue #7.

- **Backend (Java 21 / Spring Boot 3.3.0)**: REST API that fetches 1-year historical data from Yahoo Finance and returns log returns, annualized volatility, and period metadata
- **Frontend (Angular 18 / Bootstrap 5.3)**: Standalone-component dashboard with stock symbol search, metrics cards (volatility, avg log return, period), price sparkline, and paginated daily log returns table
- **Architecture**: `architecture.md` updated with full system diagram, data flow, component table, and API reference

## Changes

### Backend
| File | Description |
|------|-------------|
| `StockController.java` | `GET /api/stock/{symbol}/metrics` + health endpoint |
| `StockService.java` | Yahoo Finance fetch, `ln(P_t/P_{t-1})` log returns, `std_dev × √252` annualized volatility |
| `StockMetrics.java` | Response DTO |
| `StockDataException.java` | Domain exception for bad symbol / API errors |
| `application.properties` | Server port, logging config |
| `StockServiceTest.java` | Unit tests for log return and volatility calculations |

### Frontend
| File | Description |
|------|-------------|
| `DashboardComponent` | Stock search, metrics cards with color-coded risk level, price sparkline, log returns table |
| `StockService` | HTTP client with error handling |
| `stock-metrics.model.ts` | TypeScript interface |
| Bootstrap 5.3 dark theme | Dark-mode UI matching GitHub's color palette |

## Test plan

- [ ] `mvn test` passes (StockServiceTest — 4 unit tests)
- [ ] Backend starts: `mvn spring-boot:run` → `http://localhost:8080/api/stock/health` returns 200
- [ ] Search `AAPL` → metrics card shows volatility %, avg log return, period ~251 days
- [ ] Search invalid symbol → error message displayed
- [ ] Frontend starts: `npm install && ng serve` → `http://localhost:4200`
- [ ] End-to-end: enter symbol in UI → real-time data loads from backend

Closes #7